### PR TITLE
Track contract JSON as dependency

### DIFF
--- a/index.js
+++ b/index.js
@@ -84,6 +84,8 @@ module.exports = async function loader(source) {
       const deps = await getLocalDependencies(contractName, contractsBuildDirectory, contractFolderPath);
       // add these imports as dependencies for a contract
       deps.map(imp => addDependency(imp));
+      // add the json file as dependency
+      addDependency(compiledContractPath);
       // return result to webpack
       callback(null, solJSON);
     } else {


### PR DESCRIPTION
This instructs webpack to reload when the compiled JSON file is modified. Otherwise, only the solidity file is tracked. This causes the artifact *not* to be reloaded when the user creates a new instance (since the JSON file is modified with the deployed address, but the solidity file is untouched), at least when the hot-loader is configured but disabled (eg in tutorial-kit).